### PR TITLE
Updated Health and Stamina Bars

### DIFF
--- a/HumanResources-GODOT/scenes/hud/stats/user_interface.tscn
+++ b/HumanResources-GODOT/scenes/hud/stats/user_interface.tscn
@@ -6,9 +6,29 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_a4qt7"]
 bg_color = Color(0, 0.709804, 0.2, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.0980392, 0.0980392, 0.0980392, 1)
+border_blend = true
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_12oso"]
 bg_color = Color(0.741176, 0, 0, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.0980392, 0.0980392, 0.0980392, 1)
+border_blend = true
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
 [node name="UserInterface" type="Control"]
 layout_mode = 3
@@ -45,6 +65,7 @@ offset_top = 32.0
 offset_right = 358.0
 offset_bottom = 66.0
 theme_override_styles/fill = SubResource("StyleBoxFlat_12oso")
+rounded = true
 show_percentage = false
 script = ExtResource("3_6p4fw")
 


### PR DESCRIPTION
I noticed that the health and stamina bars have sharp corners when full, but become rounded when they decrease.

I added a 7 pixel rounding to all four corners to match the rounding of the grey background of the bars.

I also added a 2 pixel black border (Hex: 191919) with blend enabled to help the bars stand out from the background a little bit better.

The only file edited to do this is:
        HumanResources-WIP\HumanResources-GODOT\scenes\hud\stats\user_interface.tscn

I saw there was a HudRefinement branch, but I didn't think I should edit off of that one since it was 26 commits behind the main branch.

Also, a bug I noticed while playing is that while walking from the starter room into the corridor, the player sometimes gets stuck on the line where the main room ends and the corridor begins. However, sprinting will eliminate this issue and the player can travel between rooms. This bug occurred both before and after I made any changes to the game. 

I am editing off of the darien-v/collisionFixes push to the main branch.